### PR TITLE
Fix code scanning alert no. 20: Implicit narrowing conversion in compound assignment

### DIFF
--- a/apps/samples/3DViewer/src/main/java/com/javafx/experiments/shape3d/SkinningMesh.java
+++ b/apps/samples/3DViewer/src/main/java/com/javafx/experiments/shape3d/SkinningMesh.java
@@ -188,7 +188,7 @@ public class SkinningMesh extends PolygonMesh {
 
         updateLocalToGlobalTransforms(jointIndexForest);
 
-        float[] points = new float[nPoints*3];
+        double[] points = new double[nPoints*3];
         double[] t = new double[12];
         float[] relativePoint;
         for (int j = 0; j < nJoints; j++) {
@@ -200,7 +200,7 @@ public class SkinningMesh extends PolygonMesh {
                 points[3*i+2] += weights[j][i] * (t[8] * relativePoint[3*i] + t[9] * relativePoint[3*i+1] + t[10] * relativePoint[3*i+2] + t[11]);
             }
         }
-        getPoints().set(0, points, 0, points.length);
+        getPoints().setAll(points, 0, points.length);
 
         jointsTransformDirty = false;
     }


### PR DESCRIPTION
Fixes [https://github.com/rncscox/rncsjfx/security/code-scanning/20](https://github.com/rncscox/rncsjfx/security/code-scanning/20)

To fix the problem, we need to ensure that the type of the left-hand side of the compound assignment statement is at least as wide as the type of the right-hand side. In this case, we should change the type of the `points` array from `float[]` to `double[]`. This will prevent any implicit narrowing conversion and maintain the precision of the calculations.

- Change the type of the `points` array from `float[]` to `double[]`.
- Update the method call to `getPoints().set` to handle the `double[]` array correctly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
